### PR TITLE
make question accepted by default

### DIFF
--- a/pyconde_talks/urls.py
+++ b/pyconde_talks/urls.py
@@ -18,7 +18,6 @@ from talks.views_qa import (
     QuestionCreateView,
     QuestionListView,
     QuestionUpdateView,
-    approve_question,
     delete_question,
     mark_question_answered,
     reject_question,
@@ -56,7 +55,6 @@ urlpatterns = [
     path("questions/<int:question_id>/vote/", vote_question, name="question_vote"),
     path("questions/<int:question_id>/edit/", QuestionUpdateView.as_view(), name="question_edit"),
     path("questions/<int:question_id>/delete/", delete_question, name="question_delete"),
-    path("questions/<int:question_id>/approve/", approve_question, name="question_approve"),
     path("questions/<int:question_id>/reject/", reject_question, name="question_reject"),
     path(
         "questions/<int:question_id>/mark-answered/",

--- a/talks/admin.py
+++ b/talks/admin.py
@@ -376,7 +376,7 @@ class QuestionAdmin(admin.ModelAdmin):
     )
     list_filter = ("status", "created_at", "talk__title")
     search_fields = ("content", "user__email", "user__first_name", "user__last_name", "talk__title")
-    actions: ClassVar[list[str]] = ["approve_questions", "reject_questions", "mark_as_answered"]
+    actions: ClassVar[list[str]] = ["reject_questions", "mark_as_answered"]
     readonly_fields = ("vote_count", "created_at", "updated_at")
     inlines: ClassVar[list[type[admin.TabularInline]]] = [AnswerInline]
 
@@ -419,19 +419,15 @@ class QuestionAdmin(admin.ModelAdmin):
         """Display the number of votes for this question."""
         return obj.vote_count
 
-    @admin.action(description=_("Approve selected questions"))
-    def approve_questions(self, request: HttpRequest, queryset: QuerySet) -> None:
-        """Mark selected questions as approved."""
-        for question in queryset:
-            question.approve()
-        self.message_user(request, _("Questions have been approved."))
-
-    @admin.action(description=_("Reject selected questions"))
+    @admin.action(description=_("Reject selected questions (hide from public)"))
     def reject_questions(self, request: HttpRequest, queryset: QuerySet) -> None:
-        """Mark selected questions as rejected."""
+        """Mark selected questions as rejected, hiding them from public view."""
         for question in queryset:
             question.reject()
-        self.message_user(request, _("Questions have been rejected."))
+        self.message_user(
+            request,
+            _("Questions have been rejected and will not appear in public view."),
+        )
 
     @admin.action(description=_("Mark selected questions as answered"))
     def mark_as_answered(self, request: HttpRequest, queryset: QuerySet) -> None:

--- a/talks/models_qa.py
+++ b/talks/models_qa.py
@@ -39,10 +39,6 @@ class QuestionQuerySet(models.QuerySet):
         """Return only answered questions."""
         return self.filter(status=Question.Status.ANSWERED)
 
-    def pending(self) -> QuerySet:
-        """Return only pending questions."""
-        return self.filter(status=Question.Status.PENDING)
-
     def not_rejected(self) -> QuerySet:
         """Return questions that haven't been rejected."""
         return self.exclude(status=Question.Status.REJECTED)
@@ -54,7 +50,6 @@ class Question(models.Model):
     class Status(models.TextChoices):
         """Status of a question."""
 
-        PENDING = "pending", _("Pending")
         APPROVED = "approved", _("Approved")
         ANSWERED = "answered", _("Answered")
         REJECTED = "rejected", _("Rejected")
@@ -82,7 +77,7 @@ class Question(models.Model):
     status = models.CharField(
         max_length=10,
         choices=Status.choices,
-        default=Status.PENDING,
+        default=Status.APPROVED,
         help_text=_("Status of the question"),
     )
 
@@ -151,11 +146,6 @@ class Question(models.Model):
     def mark_as_answered(self) -> None:
         """Mark the question as answered."""
         self.status = self.Status.ANSWERED
-        self.save(update_fields=["status", "updated_at"])
-
-    def approve(self) -> None:
-        """Approve the question."""
-        self.status = self.Status.APPROVED
         self.save(update_fields=["status", "updated_at"])
 
     def reject(self) -> None:

--- a/templates/talks/questions/question_list_fragment.html
+++ b/templates/talks/questions/question_list_fragment.html
@@ -24,17 +24,15 @@
           <option value="all" {% if status_filter == 'all' %}selected{% endif %}>{% translate "All" %}</option>
           <option value="mine" {% if status_filter == 'mine' %}selected{% endif %}>{% translate "My questions" %}</option>
           {% if user_can_moderate %}
-            <option value="pending"
-                    {% if status_filter == 'pending' %}selected{% endif %}>{% translate "Pending" %}</option>
             <option value="approved"
-                    {% if status_filter == 'approved' %}selected{% endif %}>{% translate "Approved" %}</option>
+                    {% if status_filter == 'approved' %}selected{% endif %}>{% translate "Active" %}</option>
             <option value="answered"
                     {% if status_filter == 'answered' %}selected{% endif %}>{% translate "Answered" %}</option>
             <option value="rejected"
                     {% if status_filter == 'rejected' %}selected{% endif %}>{% translate "Rejected" %}</option>
           {% else %}
             <option value="approved"
-                    {% if status_filter == 'approved' %}selected{% endif %}>{% translate "Approved" %}</option>
+                    {% if status_filter == 'approved' %}selected{% endif %}>{% translate "Active" %}</option>
             <option value="answered"
                     {% if status_filter == 'answered' %}selected{% endif %}>{% translate "Answered" %}</option>
           {% endif %}
@@ -56,7 +54,7 @@
     <div class="alert-warning mb-4">
       <p class="font-medium">{% translate "Moderator View" %}</p>
       <p class="text-sm">
-        {% translate "You are viewing this page as a moderator and can see all questions including pending and rejected ones." %}
+        {% translate "You are viewing this page as a moderator. All questions are visible by default. You can reject questions that violate guidelines or are inappropriate." %}
       </p>
     </div>
   {% endif %}
@@ -71,11 +69,7 @@
           <div class="flex items-center justify-between mb-2">
             <span class="text-sm text-muted">{{ question.display_name }}</span>
             <!-- Status badges -->
-            {% if question.status == 'pending' %}
-              <span class="badge badge-yellow text-xs px-2 py-1">{% translate "Pending" %}</span>
-            {% elif question.status == 'approved' %}
-              <span class="badge badge-green text-xs px-2 py-1">{% translate "Approved" %}</span>
-            {% elif question.status == 'answered' %}
+            {% if question.status == 'answered' %}
               <span class="badge badge-blue text-xs px-2 py-1">{% translate "Answered" %}</span>
             {% elif question.status == 'rejected' %}
               <span class="badge badge-red text-xs px-2 py-1">{% translate "Rejected" %}</span>
@@ -90,37 +84,14 @@
           {% if user_can_moderate or question.user_id == request.user.id %}
             <div class="flex flex-wrap gap-2 mt-2">
               {% if user_can_moderate %}
-                {# Pending: can approve, reject, answer #}
-                {% if question.status == 'pending' %}
-                  <button class="text-sm inline-flex items-center gap-1 badge badge-green hover:bg-green-200 px-2 py-1"
-                          hx-post="{% url 'question_approve' question.id %}"
-                          hx-vals='{"status_filter":"{{ status_filter }}"}'
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-target="#question-list"
-                          hx-swap="outerHTML">{% svg 'check-circle' "h-4 w-4" %} {% translate "Approve" %}</button>
-                  <button class="text-sm inline-flex items-center gap-1 badge hover:bg-red-200 px-2 py-1 bg-red-100 text-red-700"
-                          hx-post="{% url 'question_reject' question.id %}"
-                          hx-vals='{"status_filter":"{{ status_filter }}"}'
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-target="#question-list"
-                          hx-swap="outerHTML">{% svg 'x-mark' "h-4 w-4" %} {% translate "Reject" %}</button>
-                  <button class="text-sm inline-flex items-center gap-1 badge badge-blue hover:bg-blue-200 px-2 py-1"
-                          hx-post="{% url 'question_mark_answered' question.id %}"
-                          hx-vals='{"status_filter":"{{ status_filter }}"}'
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-target="#question-list"
-                          hx-swap="outerHTML">
-                    {% svg 'chat-bubble-left-ellipsis' "h-4 w-4" %} {% translate "Mark Answered" %}
-                  </button>
-                {% endif %}
-                {# Approved: can reject or answer #}
+                {# Questions can be either rejected or marked as answered #}
                 {% if question.status == 'approved' %}
-                  <button class="text-sm inline-flex items-center gap-1 badge hover:bg-red-200 px-2 py-1 bg-red-100 text-red-700"
+                  <button class="text-sm inline-flex items-center gap-1 badge badge-red hover:bg-red-200 px-2 py-1"
                           hx-post="{% url 'question_reject' question.id %}"
                           hx-vals='{"status_filter":"{{ status_filter }}"}'
                           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                           hx-target="#question-list"
-                          hx-swap="outerHTML">{% svg 'x-mark' "h-4 w-4" %} {% translate "Reject" %}</button>
+                          hx-swap="outerHTML">{% svg 'x-mark' "h-4 w-4" %} {% translate "Reject Question" %}</button>
                   <button class="text-sm inline-flex items-center gap-1 badge badge-blue hover:bg-blue-200 px-2 py-1"
                           hx-post="{% url 'question_mark_answered' question.id %}"
                           hx-vals='{"status_filter":"{{ status_filter }}"}'
@@ -130,31 +101,14 @@
                     {% svg 'chat-bubble-left-ellipsis' "h-4 w-4" %} {% translate "Mark Answered" %}
                   </button>
                 {% endif %}
-                {# Answered: can move to approved or reject #}
+                {# Answered: can be rejected #}
                 {% if question.status == 'answered' %}
-                  <button class="text-sm inline-flex items-center gap-1 badge badge-green hover:bg-green-200 px-2 py-1"
-                          hx-post="{% url 'question_approve' question.id %}"
-                          hx-vals='{"status_filter":"{{ status_filter }}"}'
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-target="#question-list"
-                          hx-swap="outerHTML">
-                    {% svg 'check-circle' "h-4 w-4" %} {% translate "Mark Approved" %}
-                  </button>
-                  <button class="text-sm inline-flex items-center gap-1 badge hover:bg-red-200 px-2 py-1 bg-red-100 text-red-700"
+                  <button class="text-sm inline-flex items-center gap-1 badge badge-red hover:bg-red-200 px-2 py-1"
                           hx-post="{% url 'question_reject' question.id %}"
                           hx-vals='{"status_filter":"{{ status_filter }}"}'
                           hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                           hx-target="#question-list"
-                          hx-swap="outerHTML">{% svg 'x-mark' "h-4 w-4" %} {% translate "Reject" %}</button>
-                {% endif %}
-                {# Rejected: can move to approved #}
-                {% if question.status == 'rejected' %}
-                  <button class="text-sm inline-flex items-center gap-1 badge badge-green hover:bg-green-200 px-2 py-1"
-                          hx-post="{% url 'question_approve' question.id %}"
-                          hx-vals='{"status_filter":"{{ status_filter }}"}'
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-target="#question-list"
-                          hx-swap="outerHTML">{% svg 'check-circle' "h-4 w-4" %} {% translate "Approve" %}</button>
+                          hx-swap="outerHTML">{% svg 'x-mark' "h-4 w-4" %} {% translate "Reject Question" %}</button>
                 {% endif %}
               {% endif %}
               {% if question.user_id == request.user.id %}

--- a/templates/talks/questions/question_success.html
+++ b/templates/talks/questions/question_success.html
@@ -17,15 +17,9 @@
        class="hidden"></div>
   <p class="text-brand-green">
     {% load i18n %}
-    {% if user_can_moderate %}
-      {% translate "Your question has been posted and is now visible." %}
-    {% else %}
-      {% translate "Your question has been submitted successfully and is now awaiting approval." %}
-    {% endif %}
+    {% translate "Your question has been posted and is now visible." %}
   </p>
-  {% if not user_can_moderate %}
-    <p class="text-sm text-brand-green mt-2">
-      {% translate "Once approved by a moderator, your question will appear in the list and others can vote on it." %}
-    </p>
-  {% endif %}
+  <p class="text-sm text-brand-green mt-2">
+    {% translate "Other participants can now see and vote on your question." %}
+  </p>
 </div>


### PR DESCRIPTION
# Overview 
This pull request removes the "pending" status and the approval workflow for questions. All new questions are now automatically approved and visible by default. The admin and moderator interfaces, as well as user-facing messages and filtering, have been updated to reflect this simplified process. Moderators can still reject or mark questions as answered, but there is no longer an "approve" action or "pending" state.

The main logic is to simplify the life of the moderator. Most people are nice; therefore, most questions will be approved. If someone wants to be nasty/they can anyway post what he/she want on Discord until he/she is kicked out (nearly never happened). 