### PR TITLE
Adding session chair planning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ logs/*
 staticfiles/
 static/css/tailwind.min.css
 
+# Fonts downloaded at setup time (see scripts/dev-setup.sh)
+assets/fonts/
+
 # Test coverage
 .coverage
 lcov.info

--- a/talks/migrations/0022_talk_session_chair.py
+++ b/talks/migrations/0022_talk_session_chair.py
@@ -1,0 +1,19 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('talks', '0021_alter_talk_presentation_type'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='talk',
+            name='session_chair',
+            field=models.ForeignKey(blank=True, help_text='User who volunteered to chair this session', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='chaired_talks', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/talks/models.py
+++ b/talks/models.py
@@ -377,6 +377,14 @@ class Talk(models.Model):
         blank=True,
         help_text=_("Event this talk belongs to"),
     )
+    session_chair = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        related_name="chaired_talks",
+        null=True,
+        blank=True,
+        help_text=_("User who volunteered to chair this session"),
+    )
     hide = models.BooleanField(
         default=False,
         help_text=_("Hide this talk from the public"),
@@ -433,6 +441,24 @@ class Talk(models.Model):
         self.video_link = self._enrich_video_link()
 
         super().save(*args, **kwargs)
+
+    @property
+    def chair_display_name(self) -> str:
+        """
+        Return the session chair's name, or an empty string when unassigned.
+
+        Prefer the chosen display name, then the full name, and fall back to the plain email. Only
+        moderators ever see this value, so the email is shown verbatim rather than obfuscated.
+        """
+        chair = self.session_chair
+        if not chair:
+            return ""
+        return str(chair.display_name.strip() or chair.get_full_name().strip() or chair.email)
+
+    @property
+    def end_time(self) -> datetime:
+        """Return when the talk ends (start time plus duration)."""
+        return self.start_time + self.duration
 
     def clean(self) -> None:
         """Validate that this talk does not overlap with another in the same room."""

--- a/talks/tests/test_chair.py
+++ b/talks/tests/test_chair.py
@@ -1,0 +1,418 @@
+"""Tests for the moderator-only session-chair feature: model, block toggle, and day grid."""
+
+from datetime import timedelta
+from http import HTTPStatus
+from typing import TYPE_CHECKING
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from model_bakery import baker
+
+from events.models import Event
+from talks.models import Room, Talk
+from users.models import CustomUser
+
+
+if TYPE_CHECKING:
+    from django.test.client import Client
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture()
+def moderator() -> CustomUser:
+    """Create a moderator (staff) user."""
+    return baker.make(CustomUser, email="mod@example.com", is_staff=True)
+
+
+@pytest.fixture()
+def other_moderator() -> CustomUser:
+    """Create a second moderator user."""
+    return baker.make(CustomUser, email="mod2@example.com", is_staff=True)
+
+
+@pytest.fixture()
+def regular_user() -> CustomUser:
+    """Create a non-moderator user."""
+    return baker.make(CustomUser, email="user@example.com", is_staff=False)
+
+
+@pytest.fixture()
+def room() -> Room:
+    """Create a room for testing."""
+    return baker.make(Room, name="Main Hall")
+
+
+@pytest.fixture()
+def talk(room: Room) -> Talk:
+    """Create a single talk without an event (accessible to everyone)."""
+    return baker.make(
+        Talk,
+        title="Chair Test Talk",
+        room=room,
+        start_time=timezone.now(),
+        duration=timedelta(minutes=30),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model property tests
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestChairDisplayName:
+    """Tests for Talk.chair_display_name."""
+
+    def test_empty_when_unassigned(self, talk: Talk) -> None:
+        """An unassigned session returns an empty string."""
+        assert talk.chair_display_name == ""
+
+    def test_prefers_display_name(self, talk: Talk) -> None:
+        """The chosen display name wins over other fields."""
+        chair = baker.make(CustomUser, email="x@example.com", display_name="Ada L.")
+        talk.session_chair = chair
+        assert talk.chair_display_name == "Ada L."
+
+    def test_falls_back_to_full_name(self, talk: Talk) -> None:
+        """Without a display name, the full name is used."""
+        chair = baker.make(
+            CustomUser,
+            email="x@example.com",
+            display_name="",
+            first_name="Grace",
+            last_name="Hopper",
+        )
+        talk.session_chair = chair
+        assert talk.chair_display_name == "Grace Hopper"
+
+    def test_falls_back_to_plain_email(self, talk: Talk) -> None:
+        """Without any name, the plain (non-obfuscated) email is shown."""
+        chair = baker.make(CustomUser, email="plain@example.com", display_name="")
+        talk.session_chair = chair
+        assert talk.chair_display_name == "plain@example.com"
+
+
+@pytest.mark.django_db
+class TestTalkEndTime:
+    """Tests for Talk.end_time."""
+
+    def test_end_time_is_start_plus_duration(self, talk: Talk) -> None:
+        """end_time equals start_time plus the talk's duration."""
+        talk.duration = timedelta(minutes=45)
+        assert talk.end_time == talk.start_time + timedelta(minutes=45)
+
+
+# ---------------------------------------------------------------------------
+# toggle_session_chair view tests
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestToggleSessionChair:
+    """Tests for the toggle_session_chair view."""
+
+    def test_non_moderator_forbidden(
+        self,
+        client: Client,
+        regular_user: CustomUser,
+        talk: Talk,
+    ) -> None:
+        """A non-moderator cannot assign a chair."""
+        client.force_login(regular_user)
+        url = reverse("toggle_session_chair", args=[talk.pk])
+        response = client.post(url)
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    def test_claim_single_talk(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        talk: Talk,
+    ) -> None:
+        """A moderator can claim a standalone session."""
+        client.force_login(moderator)
+        url = reverse("toggle_session_chair", args=[talk.pk])
+        response = client.post(url)
+        assert response.status_code == HTTPStatus.FOUND
+        talk.refresh_from_db()
+        assert talk.session_chair_id == moderator.pk
+
+    def test_claim_assigns_whole_block(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        room: Room,
+    ) -> None:
+        """Claiming one talk chairs the whole back-to-back block."""
+        start = timezone.now()
+        first = baker.make(
+            Talk,
+            title="Block 1",
+            room=room,
+            start_time=start,
+            duration=timedelta(minutes=30),
+        )
+        second = baker.make(
+            Talk,
+            title="Block 2",
+            room=room,
+            start_time=start + timedelta(minutes=30),
+            duration=timedelta(minutes=30),
+        )
+        # A talk much later in the same room is a separate block.
+        far = baker.make(
+            Talk,
+            title="Later",
+            room=room,
+            start_time=start + timedelta(hours=3),
+            duration=timedelta(minutes=30),
+        )
+        client.force_login(moderator)
+        client.post(reverse("toggle_session_chair", args=[first.pk]))
+        first.refresh_from_db()
+        second.refresh_from_db()
+        far.refresh_from_db()
+        assert first.session_chair_id == moderator.pk
+        assert second.session_chair_id == moderator.pk
+        assert far.session_chair_id is None
+
+    def test_release_clears_whole_block(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        room: Room,
+    ) -> None:
+        """Stepping down clears the whole block the moderator chaired."""
+        start = timezone.now()
+        first = baker.make(
+            Talk,
+            title="Block 1",
+            room=room,
+            start_time=start,
+            duration=timedelta(minutes=30),
+            session_chair=moderator,
+        )
+        second = baker.make(
+            Talk,
+            title="Block 2",
+            room=room,
+            start_time=start + timedelta(minutes=30),
+            duration=timedelta(minutes=30),
+            session_chair=moderator,
+        )
+        client.force_login(moderator)
+        client.post(reverse("toggle_session_chair", args=[second.pk]))
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.session_chair_id is None
+        assert second.session_chair_id is None
+
+    def test_cannot_override_another_chair(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        other_moderator: CustomUser,
+        talk: Talk,
+    ) -> None:
+        """A moderator cannot take over a block chaired by someone else."""
+        talk.session_chair = other_moderator
+        talk.save(update_fields=["session_chair"])
+        client.force_login(moderator)
+        url = reverse("toggle_session_chair", args=[talk.pk])
+        client.post(url)
+        talk.refresh_from_db()
+        assert talk.session_chair_id == other_moderator.pk
+
+    def test_htmx_returns_grid_table(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        talk: Talk,
+    ) -> None:
+        """An HTMX request gets the grid table fragment back, not a redirect."""
+        client.force_login(moderator)
+        url = reverse("toggle_session_chair", args=[talk.pk])
+        response = client.post(url, HTTP_HX_REQUEST="true")
+        assert response.status_code == HTTPStatus.OK
+        assert b"chair-grid-table" in response.content
+
+    def test_no_event_access_returns_404(
+        self,
+        client: Client,
+        moderator: CustomUser,
+    ) -> None:
+        """A moderator cannot chair a talk from an event they cannot access."""
+        event = baker.make(Event, is_active=True)
+        restricted = baker.make(Talk, event=event, start_time=timezone.now())
+        client.force_login(moderator)
+        url = reverse("toggle_session_chair", args=[restricted.pk])
+        response = client.post(url)
+        assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+# ---------------------------------------------------------------------------
+# chair_grid_view tests
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestChairGridView:
+    """Tests for the chair_grid_view."""
+
+    def test_non_moderator_forbidden(
+        self,
+        client: Client,
+        regular_user: CustomUser,
+    ) -> None:
+        """A non-moderator cannot open the chair grid."""
+        client.force_login(regular_user)
+        response = client.get(reverse("chair_grid"))
+        assert response.status_code == HTTPStatus.FORBIDDEN
+
+    def test_renders_grid_with_chair_button(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        talk: Talk,
+    ) -> None:
+        """The grid renders an unassigned talk with a Chair button."""
+        client.force_login(moderator)
+        response = client.get(reverse("chair_grid"))
+        assert response.status_code == HTTPStatus.OK
+        assert b"Chair Test Talk" in response.content
+        assert b"Chair" in response.content
+
+    def test_does_not_leak_other_event(
+        self,
+        client: Client,
+        moderator: CustomUser,
+    ) -> None:
+        """Passing another event's id must not reveal its talks."""
+        room = baker.make(Room, name="Hidden Hall")
+        event = baker.make(Event, is_active=True)
+        when = timezone.now()
+        baker.make(Talk, title="Secret Session", room=room, event=event, start_time=when)
+        client.force_login(moderator)
+        response = client.get(
+            reverse("chair_grid"),
+            {"event": str(event.pk), "date": when.date().isoformat()},
+        )
+        assert response.status_code == HTTPStatus.OK
+        assert b"Secret Session" not in response.content
+
+    def test_shows_chair_name(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        room: Room,
+    ) -> None:
+        """An assigned chair's name appears in the grid."""
+        chair = baker.make(CustomUser, email="z@example.com", display_name="Linus T.")
+        baker.make(
+            Talk,
+            title="Chaired Session",
+            room=room,
+            session_chair=chair,
+            start_time=timezone.now(),
+            duration=timedelta(minutes=30),
+        )
+        client.force_login(moderator)
+        response = client.get(reverse("chair_grid"))
+        assert response.status_code == HTTPStatus.OK
+        assert b"Linus T." in response.content
+
+    def test_block_talks_share_block_id(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        room: Room,
+    ) -> None:
+        """Back-to-back talks in a room share a data-block id so the UI can highlight them."""
+        start = timezone.now()
+        baker.make(
+            Talk,
+            title="Block A",
+            room=room,
+            start_time=start,
+            duration=timedelta(minutes=30),
+        )
+        baker.make(
+            Talk,
+            title="Block B",
+            room=room,
+            start_time=start + timedelta(minutes=30),
+            duration=timedelta(minutes=30),
+        )
+        client.force_login(moderator)
+        response = client.get(reverse("chair_grid"), {"date": start.date().isoformat()})
+        content = response.content.decode()
+        # Both talks belong to the first block of their room (index 0).
+        talks_in_block = 2
+        assert content.count(f'data-block="{room.pk}-0"') == talks_in_block
+
+    def test_my_blocks_are_marked(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        room: Room,
+    ) -> None:
+        """Cells chaired by the current user carry the persistent highlight class."""
+        baker.make(
+            Talk,
+            title="Mine",
+            room=room,
+            session_chair=moderator,
+            start_time=timezone.now(),
+            duration=timedelta(minutes=30),
+        )
+        client.force_login(moderator)
+        response = client.get(reverse("chair_grid"))
+        assert b"chair-mine" in response.content
+
+
+# ---------------------------------------------------------------------------
+# Talk detail page tests
+# ---------------------------------------------------------------------------
+@pytest.mark.django_db
+class TestChairOnDetailPage:
+    """Tests for the read-only chair name on the talk detail page."""
+
+    def test_moderator_sees_chair_name(
+        self,
+        client: Client,
+        moderator: CustomUser,
+        room: Room,
+    ) -> None:
+        """A moderator sees the assigned chair on the detail page."""
+        chair = baker.make(CustomUser, email="z@example.com", display_name="Chair Person")
+        detail_talk = baker.make(
+            Talk,
+            title="Detail Talk",
+            room=room,
+            session_chair=chair,
+            start_time=timezone.now(),
+            duration=timedelta(minutes=30),
+        )
+        client.force_login(moderator)
+        response = client.get(reverse("talk_detail", args=[detail_talk.pk]))
+        assert response.status_code == HTTPStatus.OK
+        assert b"Session chair" in response.content
+        assert b"Chair Person" in response.content
+
+    def test_regular_user_does_not_see_chair_name(
+        self,
+        client: Client,
+        regular_user: CustomUser,
+        room: Room,
+    ) -> None:
+        """A regular user never sees the session chair on the detail page."""
+        chair = baker.make(CustomUser, email="z@example.com", display_name="Chair Person")
+        detail_talk = baker.make(
+            Talk,
+            title="Detail Talk",
+            room=room,
+            session_chair=chair,
+            start_time=timezone.now(),
+            duration=timedelta(minutes=30),
+        )
+        client.force_login(regular_user)
+        response = client.get(reverse("talk_detail", args=[detail_talk.pk]))
+        assert response.status_code == HTTPStatus.OK
+        assert b"Session chair" not in response.content

--- a/talks/urls.py
+++ b/talks/urls.py
@@ -9,6 +9,7 @@ from .views import (
     talk_redirect_view,
     upcoming_talks,
 )
+from .views_chair import chair_grid_view, toggle_session_chair
 from .views_qa import (
     QuestionCreateView,
     QuestionListView,
@@ -28,6 +29,7 @@ from .views_schedule import schedule_view
 urlpatterns = [
     path("", TalkListView.as_view(), name="talk_list"),
     path("schedule/", schedule_view, name="schedule"),
+    path("chairs/", chair_grid_view, name="chair_grid"),
     path("<int:pk>/", TalkDetailView.as_view(), name="talk_detail"),
     path("dashboard-stats/", dashboard_stats, name="dashboard_stats"),
     path("upcoming-talks/", upcoming_talks, name="upcoming_talks"),
@@ -37,6 +39,8 @@ urlpatterns = [
     path("<int:talk_id>/rating-stats/", get_talk_rating_stats, name="talk_rating_stats"),
     # Save/Bookmark URLs
     path("<int:talk_id>/save/", toggle_save_talk, name="toggle_save_talk"),
+    # Session-chair URLs
+    path("<int:talk_id>/chair/", toggle_session_chair, name="toggle_session_chair"),
     path("<str:talk_id>/", talk_redirect_view, name="talk_redirect"),
     # Q&A URLs
     path("<int:talk_id>/questions/", QuestionListView.as_view(), name="talk_questions"),

--- a/talks/views.py
+++ b/talks/views.py
@@ -75,6 +75,9 @@ class TalkDetailView(DetailView[Talk]):
             context["average_rating"] = None
         context["show_rating_summary"] = show_summary
 
+        # Only moderators see the assigned session chair on the detail page.
+        context["user_can_moderate"] = is_moderator(self.request.user)
+
         # Get user's existing rating if authenticated
         if self.request.user.is_authenticated:
             context["user_rating"] = Rating.objects.filter(

--- a/talks/views_chair.py
+++ b/talks/views_chair.py
@@ -1,0 +1,284 @@
+"""
+Session-chair views (moderator-only).
+
+Lets a moderator volunteer (or step down) as the session chair for a block of adjacent talks in
+the same room and renders a day grid (times on the left, rooms across the top) showing who is
+chairing each session.
+"""
+
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any, cast
+
+from django.core.exceptions import PermissionDenied
+from django.db.models.functions import TruncDate
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
+from django.utils import timezone
+from django.views.decorators.http import require_POST, require_safe
+
+from events.session import resolve_default_event
+
+from .models import FAR_FUTURE, Room, Talk
+from .utils import is_htmx_request
+from .views_qa import is_moderator
+
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest, HttpResponse
+
+    from users.models import CustomUser
+
+
+# Talks in the same room are treated as one block when the gap between them is at most this long.
+BLOCK_GAP_TOLERANCE = timedelta(minutes=5)
+
+
+def _require_moderator(user: CustomUser) -> None:
+    """Raise PermissionDenied unless the user is a moderator."""
+    if not is_moderator(user):
+        raise PermissionDenied
+
+
+def _parse_chair_date(date_str: str | None) -> date | None:
+    """Parse a YYYY-MM-DD string into a date, returning None on failure."""
+    if not date_str:
+        return None
+    try:
+        return datetime.strptime(date_str, "%Y-%m-%d").date()  # noqa: DTZ007
+    except ValueError:
+        return None
+
+
+def _talk_block(talk: Talk, user: CustomUser) -> list[Talk]:
+    """
+    Return the contiguous block of talks the given talk belongs to.
+
+    A block is the run of talks in the same room and event whose neighbors are no more than
+    ``BLOCK_GAP_TOLERANCE`` apart, so a moderator chairs a whole stretch of back-to-back sessions
+    (for example a series of lightning talks) in one click.
+    """
+    if not talk.room or not talk.start_time:
+        return [talk]
+
+    day_talks = list(
+        Talk.objects.filter(
+            room=talk.room,
+            event_id=talk.event_id,
+            start_time__date=talk.start_time.date(),
+        )
+        .exclude(start_time__year=FAR_FUTURE.year)
+        .accessible_to(user)
+        .order_by("start_time"),
+    )
+
+    try:
+        index = next(i for i, t in enumerate(day_talks) if t.pk == talk.pk)
+    except StopIteration:
+        return [talk]
+
+    # Expand left while the previous talk ends within tolerance of the current one's start.
+    start = index
+    while start > 0:
+        prev = day_talks[start - 1]
+        prev_end = prev.start_time + prev.duration
+        if day_talks[start].start_time - prev_end > BLOCK_GAP_TOLERANCE:
+            break
+        start -= 1
+
+    # Expand right while the next talk starts within tolerance of the current one's end.
+    end = index
+    while end < len(day_talks) - 1:
+        cur_end = day_talks[end].start_time + day_talks[end].duration
+        if day_talks[end + 1].start_time - cur_end > BLOCK_GAP_TOLERANCE:
+            break
+        end += 1
+
+    return day_talks[start : end + 1]
+
+
+@require_POST
+def toggle_session_chair(request: HttpRequest, talk_id: int) -> HttpResponse:
+    """
+    Claim (or release) the current moderator as chair for a talk's whole block.
+
+    A block can only have one chair at a time. A moderator may claim a free block or release a
+    block they already chair, but cannot take over a block someone else is chairing.
+    """
+    user = cast("CustomUser", request.user)
+    _require_moderator(user)
+
+    talk = get_object_or_404(Talk.objects.accessible_to(user), pk=talk_id)
+    block = _talk_block(talk, user)
+
+    # Only the chair (or nobody) may change a block; never override another moderator.
+    if talk.session_chair_id in (None, user.pk):
+        new_chair = None if talk.session_chair_id == user.pk else user
+        for block_talk in block:
+            if block_talk.session_chair_id in (None, user.pk):
+                block_talk.session_chair = new_chair
+                block_talk.save(update_fields=["session_chair", "updated_at"])
+
+    selected_date = talk.start_time.date() if talk.start_time else None
+    selected_event = request.POST.get("event", "")
+
+    if is_htmx_request(request):
+        event_id = int(selected_event) if selected_event.isdigit() else None
+        context = _grid_context(user, event_id, selected_date)
+        return render(request, "talks/partials/chair_grid_table.html", context)
+
+    url = reverse("chair_grid")
+    params = []
+    if selected_date:
+        params.append(f"date={selected_date.isoformat()}")
+    if selected_event:
+        params.append(f"event={selected_event}")
+    if params:
+        url = f"{url}?{'&'.join(params)}"
+    return redirect(url)
+
+
+def _chair_dates(user: CustomUser, event_id: int | None) -> list[date]:
+    """Return the available schedule dates for the chair grid, scoped to the user's access."""
+    talks_qs = Talk.objects.exclude(start_time__year=FAR_FUTURE.year).accessible_to(user)
+    if event_id:
+        talks_qs = talks_qs.filter(event_id=event_id)
+    date_qs = (
+        talks_qs.annotate(d=TruncDate("start_time"))
+        .values_list("d", flat=True)
+        .distinct()
+        .order_by("d")
+    )
+    return list(date_qs)
+
+
+def _resolve_event_id(request: HttpRequest) -> int | None:
+    """Return the event id to scope the grid by, or None for a cross-event view."""
+    event_param = request.GET.get("event", "")
+    if event_param:
+        return int(event_param) if event_param.isdigit() else None
+    default_event = resolve_default_event(request)
+    return default_event.pk if default_event else None
+
+
+def _resolve_selected_date(request: HttpRequest, available_dates: list[date]) -> date | None:
+    """Pick the chair grid date: user's ?date, then today, then the first available date."""
+    selected = _parse_chair_date(request.GET.get("date"))
+    if selected in available_dates:
+        return selected
+    today = timezone.localdate()
+    if today in available_dates:
+        return today
+    return available_dates[0] if available_dates else None
+
+
+def _assign_block_ids(talks: list[Talk]) -> None:
+    """
+    Tag each talk with a ``block_id`` attribute identifying its contiguous block.
+
+    Talks in the same room whose neighbors are within ``BLOCK_GAP_TOLERANCE`` share a block id, so
+    the grid can highlight (and chair) a whole stretch of back-to-back sessions together. The id is
+    a transient view-only attribute, never persisted.
+    """
+    talks_by_room: dict[int, list[Talk]] = {}
+    for talk in talks:
+        if talk.room:
+            talks_by_room.setdefault(talk.room_id, []).append(talk)
+
+    for room_id, room_talks in talks_by_room.items():
+        room_talks.sort(key=lambda t: t.start_time)
+        block_index = 0
+        prev_end: datetime | None = None
+        for talk in room_talks:
+            if prev_end is not None and talk.start_time - prev_end > BLOCK_GAP_TOLERANCE:
+                block_index += 1
+            talk.block_id = f"{room_id}-{block_index}"  # type: ignore[attr-defined]
+            prev_end = talk.start_time + talk.duration
+
+
+def _build_chair_grid(
+    selected_date: date,
+    user: CustomUser,
+    event_id: int | None,
+) -> tuple[list[Room], list[dict[str, Any]]]:
+    """
+    Build the chair grid for a day.
+
+    Returns ``(rooms, rows)`` where each row groups the talks that share a start time, with one
+    cell per room (or ``None`` when that room has no talk in that slot).
+    """
+    talks_qs = (
+        Talk.objects.filter(start_time__date=selected_date)
+        .exclude(start_time__year=FAR_FUTURE.year)
+        .accessible_to(user)
+        .select_related("room", "session_chair")
+        .order_by("start_time", "room__name")
+    )
+    if event_id:
+        talks_qs = talks_qs.filter(event_id=event_id)
+    talks = list(talks_qs)
+
+    # Unique rooms ordered by name, preserving only rooms that host a talk this day.
+    rooms_by_id: dict[int, Room] = {}
+    for talk in talks:
+        if talk.room and talk.room_id not in rooms_by_id:
+            rooms_by_id[talk.room_id] = talk.room
+    rooms = sorted(rooms_by_id.values(), key=lambda r: r.name)
+
+    # Tag each talk with the id of the contiguous block it belongs to, so the UI can highlight a
+    # whole block together (the same grouping used when assigning a chair).
+    _assign_block_ids(talks)
+
+    # Group talks by start time, then place each into its room column.
+    rows: list[dict[str, Any]] = []
+    talks_by_start: dict[datetime, dict[int, Talk]] = {}
+    for talk in talks:
+        if not talk.room:
+            continue
+        talks_by_start.setdefault(talk.start_time, {})[talk.room_id] = talk
+
+    for start_time in sorted(talks_by_start):
+        room_talks = talks_by_start[start_time]
+        cells = [room_talks.get(room.id) for room in rooms]
+        rows.append({"start_time": start_time, "cells": cells})
+
+    return rooms, rows
+
+
+def _grid_context(
+    user: CustomUser,
+    selected_event_id: int | None,
+    selected_date: date | None,
+) -> dict[str, Any]:
+    """Build the template context shared by the full grid page and the HTMX table fragment."""
+    available_dates = _chair_dates(user, selected_event_id)
+    rooms: list[Room] = []
+    rows: list[dict[str, Any]] = []
+    if selected_date:
+        rooms, rows = _build_chair_grid(selected_date, user, selected_event_id)
+
+    years = {d.year for d in available_dates}
+    return {
+        "available_dates": available_dates,
+        "selected_date": selected_date,
+        "has_multiple_years": len(years) > 1,
+        "rooms": rooms,
+        "rows": rows,
+        "has_grid": bool(rows),
+        "events": user.visible_events(),
+        "selected_event": str(selected_event_id) if selected_event_id else "",
+        "current_user_id": user.pk,
+    }
+
+
+@require_safe
+def chair_grid_view(request: HttpRequest) -> HttpResponse:
+    """Render the moderator-only session-chair day grid: times left, rooms across the top."""
+    user = cast("CustomUser", request.user)
+    _require_moderator(user)
+
+    selected_event_id = _resolve_event_id(request)
+    available_dates = _chair_dates(user, selected_event_id)
+    selected_date = _resolve_selected_date(request, available_dates)
+
+    context = _grid_context(user, selected_event_id, selected_date)
+    return render(request, "talks/chair_grid.html", context)

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,6 +57,9 @@
           {% if user.is_authenticated %}
             <a href="{% url 'talk_list' %}" class="hover:underline">Talks</a>
             <a href="{% url 'schedule' %}" class="hover:underline">Schedule</a>
+            {% if user.is_staff or user.is_superuser %}
+              <a href="{% url 'chair_grid' %}" class="hover:underline">Chairs</a>
+            {% endif %}
             <span>
               <a href="{% url 'user_profile' %}" class="hover:underline">Profile</a> |
               <a href="{% url 'account_logout' %}" class="hover:underline">Logout</a>

--- a/templates/talks/chair_grid.html
+++ b/templates/talks/chair_grid.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load svg_tags %}
+{% block content %}
+  <div class="w-full mx-auto p-4">
+    {# ── Header ────────────────────────────────────────────── #}
+    <div class="flex flex-wrap items-center justify-between gap-4 mb-6">
+      <h1 class="text-2xl font-bold text-heading">Session chairs</h1>
+      <a href="{% url 'schedule' %}"
+         class="btn-secondary inline-flex items-center px-3 py-1 rounded">
+        {% svg 'calendar' "h-4 w-4 mr-1" %}
+        Schedule
+      </a>
+    </div>
+    <p class="text-sm text-muted mb-4">
+      Pick a day to see who is chairing each session. Open a talk to volunteer or step down.
+    </p>
+    {# ── Day picker ────────────────────────────────────────── #}
+    <div class="flex flex-wrap gap-2 mb-4">
+      {% for d in available_dates %}
+        <a href="{% querystring date=d|date:'Y-m-d' %}"
+           class="px-4 py-2 rounded-lg font-medium text-sm transition-colors {% if d == selected_date %}bg-brand-blue text-white{% else %}bg-gray-100 text-gray-700 hover:bg-gray-200{% endif %}">
+          {% if has_multiple_years %}
+            {{ d|date:"D, M j, Y" }}
+          {% else %}
+            {{ d|date:"D, M j" }}
+          {% endif %}
+        </a>
+      {% empty %}
+        <span class="text-subtle">No scheduled days found.</span>
+      {% endfor %}
+    </div>
+    {# ── Event filter ──────────────────────────────────────── #}
+    <form method="get" class="mb-4 card-compact inline-flex">
+      <select name="event" class="form-select" onchange="this.form.submit()">
+        <option value="">All Events</option>
+        {% for event in events %}
+          <option value="{{ event.id }}"
+                  {% if event.id|stringformat:"s" == selected_event %}selected{% endif %}>{{ event.name }}</option>
+        {% endfor %}
+      </select>
+    </form>
+    {# ── Chair grid ────────────────────────────────────────── #}
+    {% include "talks/partials/chair_grid_table.html" %}
+  </div>
+  {# Persistent highlight for the blocks you chair, plus hover highlight across a whole block. #}
+  <style>
+    .chair-cell.chair-mine { background-color: rgb(219 234 254); }
+    .chair-cell.chair-block-hover { background-color: rgb(239 246 255); }
+    .chair-cell.chair-mine.chair-block-hover { background-color: rgb(191 219 254); }
+    .dark .chair-cell.chair-mine { background-color: rgba(59, 130, 246, 0.22); }
+    .dark .chair-cell.chair-block-hover { background-color: rgba(59, 130, 246, 0.12); }
+  </style>
+  <script>
+    // Highlight every cell of a block when hovering any of its talks. Uses event delegation so it
+    // keeps working after HTMX swaps the table in place.
+    (function () {
+      function setBlockHover(block, on) {
+        if (!block) return;
+        document
+          .querySelectorAll('.chair-cell[data-block="' + block + '"]')
+          .forEach(function (el) { el.classList.toggle('chair-block-hover', on); });
+      }
+      document.addEventListener('mouseover', function (e) {
+        var cell = e.target.closest && e.target.closest('.chair-cell[data-block]');
+        if (cell) setBlockHover(cell.getAttribute('data-block'), true);
+      });
+      document.addEventListener('mouseout', function (e) {
+        var cell = e.target.closest && e.target.closest('.chair-cell[data-block]');
+        if (cell) setBlockHover(cell.getAttribute('data-block'), false);
+      });
+    })();
+  </script>
+{% endblock content %}

--- a/templates/talks/partials/chair_grid_table.html
+++ b/templates/talks/partials/chair_grid_table.html
@@ -1,0 +1,84 @@
+{% load svg_tags %}
+{# Moderator-only chair grid table. Swapped in place on every assign/remove via HTMX. #}
+<div id="chair-grid-table">
+  {% if has_grid %}
+    <div class="overflow-x-auto pb-4">
+      <table class="min-w-full border-collapse text-sm">
+        <thead>
+          <tr>
+            <th class="sticky left-0 z-10 bg-gray-100 border border-gray-300 px-3 py-2 text-left text-xs font-semibold text-subtle uppercase tracking-wider">
+              Time
+            </th>
+            {% for room in rooms %}
+              <th class="bg-gray-100 border border-gray-300 px-3 py-2 text-center text-xs font-semibold text-subtle uppercase tracking-wider">
+                {{ room.name }}
+              </th>
+            {% endfor %}
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in rows %}
+            <tr>
+              <th class="sticky left-0 z-10 bg-gray-50 border border-gray-200 px-3 py-2 text-left font-medium text-muted whitespace-nowrap">
+                {{ row.start_time|date:"H:i" }}
+              </th>
+              {% for talk in row.cells %}
+                {% if talk %}
+                  <td class="chair-cell border border-gray-200 px-3 py-2 align-top {% if talk.session_chair_id == current_user_id %}chair-mine{% endif %}"
+                      data-block="{{ talk.block_id }}">
+                    <a href="{% url 'talk_detail' talk.pk %}"
+                       class="block hover:underline font-medium text-heading leading-tight line-clamp-2"
+                       title="{{ talk.title }}">{{ talk.title }}</a>
+                    <div class="mt-1 text-xs">
+                      {% if talk.session_chair_id == current_user_id %}
+                        <span class="inline-flex items-center gap-1">
+                          <span class="inline-flex items-center gap-1 text-brand-blue">
+                            {% svg 'check-circle' "h-3 w-3" %}
+                            {{ talk.chair_display_name }}
+                          </span>
+                          <button hx-post="{% url 'toggle_session_chair' talk.pk %}"
+                                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                                  hx-vals='{"event": "{{ selected_event }}"}'
+                                  hx-target="#chair-grid-table"
+                                  hx-swap="outerHTML"
+                                  class="text-subtle hover:text-red-600"
+                                  title="Remove yourself from this block">{% svg 'x-mark' "h-3 w-3" %}</button>
+                        </span>
+                      {% elif talk.session_chair_id %}
+                        <span class="inline-flex items-center gap-1 text-muted">
+                          {% svg 'check-circle' "h-3 w-3" %}
+                          {{ talk.chair_display_name }}
+                        </span>
+                      {% else %}
+                        <button hx-post="{% url 'toggle_session_chair' talk.pk %}"
+                                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                                hx-vals='{"event": "{{ selected_event }}"}'
+                                hx-target="#chair-grid-table"
+                                hx-swap="outerHTML"
+                                class="inline-flex items-center gap-1 text-subtle hover:text-brand-blue"
+                                title="Chair this block">
+                          <span class="inline-flex items-center justify-center h-4 w-4 rounded-full border border-current text-xs leading-none font-bold">+</span>
+                          Chair
+                        </button>
+                      {% endif %}
+                    </div>
+                  </td>
+                {% else %}
+                  <td class="border border-gray-200 px-3 py-2 align-top">
+                    <span class="text-subtle">-</span>
+                  </td>
+                {% endif %}
+              {% endfor %}
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    <div class="bg-surface p-6 rounded text-center text-subtle">
+      No sessions scheduled
+      {% if selected_date %}for {{ selected_date|date:"l, F j, Y" }}{% endif %}
+      .
+    </div>
+  {% endif %}
+</div>

--- a/templates/talks/talk_detail.html
+++ b/templates/talks/talk_detail.html
@@ -28,6 +28,11 @@
             {% include "talks/partials/save_button.html" %}
           </div>
           <p class="text-xl text-muted mt-2">{{ talk.speaker_names }}</p>
+          {% if user_can_moderate and talk.session_chair_id %}
+            <p class="text-sm text-muted mt-1">
+              Session chair: <span class="font-medium text-heading">{{ talk.chair_display_name }}</span>
+            </p>
+          {% endif %}
           {% if show_rating_summary %}
             <div class="mt-2" id="title-star-rating">{% star_rating average_rating rating_count %}</div>
           {% endif %}
@@ -41,7 +46,7 @@
             </div>
             <div>
               <div class="text-sm text-subtle">Time</div>
-              <div>{{ talk.start_time|date:"g:i A" }}</div>
+              <div>{{ talk.start_time|date:"g:i A" }} - {{ talk.end_time|date:"g:i A" }}</div>
             </div>
             <div>
               <div class="text-sm text-subtle">Room</div>


### PR DESCRIPTION
As suggested at the PyCon we would like to integrate session chair and volunteers.

This PR firstly concentrate on session chairs, cause this is easier to implement, we have tracks already.

So if talks are neighbours, they will combine them for one session chair slot.
Assigining using a separate table view. This only can seen by moderators, as well as the name on the talks detail page.

@jbsilva Can you have a look and add your thoughts, I could improve, if this is done, I will make a new PR for volunteer organization. 